### PR TITLE
Allow Dragula to clean up after itself if containers are added or removed

### DIFF
--- a/directive.js
+++ b/directive.js
@@ -31,6 +31,14 @@ function register (angular) {
         dragulaService.add(dragulaScope, name, drake);
       }
 
+      scope.$on('$destroy', function() {
+        var containerIndex = drake.containers.indexOf(container);
+        if (containerIndex >= 0) {
+          drake.containers.splice(containerIndex, 1);
+          drake.models.splice(containerIndex, 1);
+        }
+      });
+
       scope.$watch('dragulaModel', function (newValue, oldValue) {
         if (!newValue) {
           return;


### PR DESCRIPTION
For example via ng-if and ng-repeat may produce or destroy containers.

Resolves https://github.com/looker/helltool/issues/26930

Derived from https://github.com/bevacqua/angularjs-dragula/pull/71/files